### PR TITLE
allow custom unauthorized response

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,43 @@ It will receive a connection, username, and password.
 Easy as that!
 
 
+### Authenticating with custom response body
+
+If you want using custom unauthorized response you can pass `custom_response` in configuration like:
+
+```elixir
+
+config :your_app, your_config: [
+    username: "admin",
+    password: "simple_password",
+    realm: "Admin Area",
+    custom_response: &YouApp.Helpers.unauthorized_response/1
+  ]
+```
+
+or
+
+```elixir
+
+plug BasicAuth,
+    callback: &User.find_by_username_and_password/3,
+    realm: "Area 51",
+    custom_response: &YouApp.Helpers.unauthorized_response/1
+```
+
+Where `:custom_response` is you custom response function that takes a `conn`. Example:
+
+```elixir
+
+def unauthorized_response(conn) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.send_resp(401, ~s[{"message": "Unauthorized"}])
+  end
+
+```
+
+
 ### Authenticating only for specific actions
 
 If you're looking to authenticate only for a subset of actions in a controller you can use plug's `when action in` syntax as shown below

--- a/lib/basic_auth/configured.ex
+++ b/lib/basic_auth/configured.ex
@@ -3,7 +3,7 @@ defmodule BasicAuth.Configured do
   Basic auth plugin functions that retrieve credentials from application config.
   """
 
-  import BasicAuth.Response, only: [unauthorise: 2]
+  import BasicAuth.Response, only: [unauthorise: 3]
 
   defstruct config_options: nil
 
@@ -37,7 +37,7 @@ defmodule BasicAuth.Configured do
 
   defp send_unauthorised_response(conn, %__MODULE__{config_options: config_options}) do
     conn
-    |> unauthorise(realm(config_options))
+    |> unauthorise(realm(config_options), custom_response(config_options))
     |> Plug.Conn.halt()
   end
 
@@ -53,6 +53,12 @@ defmodule BasicAuth.Configured do
   defp password(config_options), do: credential_part!(config_options, :password)
 
   defp realm(config_options), do: credential_part(config_options, :realm)
+
+  defp custom_response({app, key}) do
+    app
+    |> Application.fetch_env!(key)
+    |> Keyword.get(:custom_response)
+  end
 
   defp credential_part({app, key}, part) do
     app

--- a/lib/basic_auth/response.ex
+++ b/lib/basic_auth/response.ex
@@ -5,10 +5,19 @@ defmodule BasicAuth.Response do
 
   @default_realm "Basic Authentication"
 
-  def unauthorise(conn, realm) do
+  def unauthorise(conn, realm, custom_response) do
     conn
     |> Plug.Conn.put_resp_header("www-authenticate", "Basic realm=\"#{realm || @default_realm}\"")
+    |> set_header_with_body(custom_response)
+  end
+
+  defp set_header_with_body(conn, custom_response) when is_function(custom_response) do
+    custom_response.(conn)
+  end
+  defp set_header_with_body(conn, _) do
+    conn
     |> Plug.Conn.put_resp_content_type("text/plain")
     |> Plug.Conn.send_resp(401, "401 Unauthorized")
   end
+
 end

--- a/lib/basic_auth/with_callback.ex
+++ b/lib/basic_auth/with_callback.ex
@@ -3,17 +3,18 @@ defmodule BasicAuth.WithCallback do
   Basic auth plugin functions callback to a provided function with credentials
   """
 
-  import BasicAuth.Response, only: [unauthorise: 2]
+  import BasicAuth.Response, only: [unauthorise: 3]
 
-  defstruct callback: nil, realm: nil
+  defstruct callback: nil, realm: nil, custom_response: nil
 
   def init(options) when is_list(options) do
     callback = Keyword.fetch!(options, :callback)
     realm = Keyword.get(options, :realm)
+    custom_response = Keyword.get(options, :custom_response)
 
     case :erlang.fun_info(callback)[:arity] do
       3 ->
-        %__MODULE__{callback: callback, realm: realm}
+        %__MODULE__{callback: callback, realm: realm, custom_response: custom_response}
 
       _ ->
         raise(
@@ -57,13 +58,13 @@ defmodule BasicAuth.WithCallback do
     end
   end
 
-  defp send_unauthorised_response(conn, %{realm: realm}) do
-    unauthorise(conn, realm)
+  defp send_unauthorised_response(conn, %{realm: realm, custom_response: custom_response}) do
+    unauthorise(conn, realm, custom_response)
   end
 
-  defp halt_and_unauthorise_response(conn, %{realm: realm}) do
+  defp halt_and_unauthorise_response(conn, %{realm: realm, custom_response: custom_response}) do
     conn
-    |> unauthorise(realm)
+    |> unauthorise(realm, custom_response)
     |> Plug.Conn.halt()
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule BasicAuth.Mixfile do
       app: :basic_auth,
       description: "Basic Authentication Plug",
       package: package(),
-      version: "2.2.3",
+      version: "2.2.4",
       elixir: "~> 1.0",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/basic_auth/configured_test.exs
+++ b/test/basic_auth/configured_test.exs
@@ -5,7 +5,8 @@ defmodule BasicAuth.ConfiguredTest do
   import BasicAuth.TestHelper,
     only: [
       call_without_credentials: 1,
-      call_with_credentials: 2
+      call_with_credentials: 2,
+      custom_response: 1
     ]
 
   defmodule SimplePlug do
@@ -75,6 +76,16 @@ defmodule BasicAuth.ConfiguredTest do
       assert conn.status == 401
     end
 
+    test "unauthorised with custom response return a 401 and custom header and body" do
+      Application.put_env(:basic_auth, :my_auth, custom_response: &custom_response/1)
+
+      conn = call_without_credentials(SimplePlug)
+
+      assert conn.status == 401
+      assert Plug.Conn.get_resp_header(conn, "content-type") == ["application/json; charset=utf-8"]
+      assert conn.resp_body == ~s[{"message": "Unauthorized"}]
+    end
+
     test "valid credentials returns a 200" do
       conn = call_with_credentials(SimplePlug, "admin:simple:password")
       assert conn.status == 200
@@ -135,4 +146,5 @@ defmodule BasicAuth.ConfiguredTest do
       assert_raise(ArgumentError, ~r/Missing/, fn -> SimplePlug.call(conn, []) end)
     end
   end
+
 end

--- a/test/basic_auth/response_test.exs
+++ b/test/basic_auth/response_test.exs
@@ -9,7 +9,7 @@ defmodule BasicAuth.ResponseTest do
       header =
         :get
         |> conn("/")
-        |> Response.unauthorise("Freddy's Kingdom")
+        |> Response.unauthorise("Freddy's Kingdom", nil)
         |> Conn.get_resp_header("www-authenticate")
 
       assert ["Basic realm=\"Freddy's Kingdom\""] == header
@@ -19,7 +19,7 @@ defmodule BasicAuth.ResponseTest do
       header =
         :get
         |> conn("/")
-        |> Response.unauthorise(nil)
+        |> Response.unauthorise(nil, nil)
         |> Conn.get_resp_header("www-authenticate")
 
       assert ["Basic realm=\"Basic Authentication\""] == header
@@ -29,7 +29,7 @@ defmodule BasicAuth.ResponseTest do
       header =
         :get
         |> conn("/")
-        |> Response.unauthorise(nil)
+        |> Response.unauthorise(nil, nil)
         |> Conn.get_resp_header("content-type")
 
       assert ["text/plain; charset=utf-8"] == header
@@ -39,9 +39,20 @@ defmodule BasicAuth.ResponseTest do
       conn =
         :get
         |> conn("/")
-        |> Response.unauthorise(nil)
+        |> Response.unauthorise(nil, nil)
 
       assert conn.status == 401
+    end
+
+    test "with custom response" do
+      conn =
+        :get
+        |> conn("/")
+        |> Response.unauthorise(nil, &BasicAuth.TestHelper.custom_response/1)
+
+      assert conn.status == 401
+      assert Plug.Conn.get_resp_header(conn, "content-type") == ["application/json; charset=utf-8"]
+      assert conn.resp_body == ~s[{"message": "Unauthorized"}]
     end
   end
 end

--- a/test/basic_auth/with_callback_test.exs
+++ b/test/basic_auth/with_callback_test.exs
@@ -1,7 +1,12 @@
 defmodule BasicAuth.WithCallbackTest do
   use ExUnit.Case, async: true
   use Plug.Test
-  import BasicAuth.TestHelper
+  import BasicAuth.TestHelper,
+    only: [
+      call_without_credentials: 1,
+      call_with_credentials: 2,
+      custom_response: 1
+    ]
 
   defmodule User do
     def find_by_username_and_password(conn, "robert", "secret:value"), do: conn
@@ -14,6 +19,10 @@ defmodule BasicAuth.WithCallbackTest do
 
   defmodule PlugWithCallbackAndRealm do
     use DemoPlug, callback: &User.find_by_username_and_password/3, realm: "Bob's Kingdom"
+  end
+
+  defmodule PlugWithCallbackAndCustomResponse do
+    use DemoPlug, callback: &User.find_by_username_and_password/3, custom_response: &custom_response/1
   end
 
   test "no credentials provided" do
@@ -46,5 +55,13 @@ defmodule BasicAuth.WithCallbackTest do
   test "incorrect basic auth formatting returns a 401" do
     conn = call_with_credentials(PlugWithCallback, "robert")
     assert conn.status == 401
+  end
+
+  test "unauthorised with custom response return a 401 and custom header and body" do
+    conn = call_with_credentials(PlugWithCallbackAndCustomResponse, "wrong:wrong")
+
+    assert conn.status == 401
+    assert Plug.Conn.get_resp_header(conn, "content-type") == ["application/json; charset=utf-8"]
+    assert conn.resp_body == ~s[{"message": "Unauthorized"}]
   end
 end

--- a/test/support/basic_auth/test_helper.ex
+++ b/test/support/basic_auth/test_helper.ex
@@ -19,4 +19,10 @@ defmodule BasicAuth.TestHelper do
     |> conn("/")
     |> plug.call([])
   end
+
+  def custom_response(conn) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.send_resp(401, ~s[{"message": "Unauthorized"}])
+  end
 end


### PR DESCRIPTION
Sometimes need send `unauthorized response` in `json` format